### PR TITLE
Fix admin endpoint references

### DIFF
--- a/guestdesk/app.py
+++ b/guestdesk/app.py
@@ -333,7 +333,7 @@ def create_app():
 
     @app.route('/login', methods=['GET', 'POST'])
     def login():
-        next_url = request.args.get('next') or url_for('admin')
+        next_url = request.args.get('next') or url_for('admin_index')
         if request.method == 'POST':
             username = (request.form.get('username') or '').strip()
             password = request.form.get('password') or ''
@@ -441,7 +441,7 @@ def create_app():
             db.commit()
             flash('Slot deleted.', 'info')
             return redirect(url_for('admin_slots', sid=sid))
-        return redirect(url_for('admin'))
+        return redirect(url_for('admin_index'))
 
     # announcements
     @app.route('/admin/announcements')


### PR DESCRIPTION
## Summary
- Correct login redirect to use `admin_index` endpoint
- Update slot deletion fallback redirect to `admin_index`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1151240c8832ea5b0961d432742e1